### PR TITLE
[FIX] account_invoice_fiscal_position_update: fix tax incl. to tax excl.

### DIFF
--- a/account_invoice_fiscal_position_update/models/account_move.py
+++ b/account_invoice_fiscal_position_update/models/account_move.py
@@ -23,7 +23,14 @@ class AccountMove(models.Model):
             if not line.product_id:
                 lines_without_product |= line
             else:
+                # Preserve the subtotal when converting from tax incl to excl
+                price_unit = line.product_id._get_tax_included_unit_price_from_price(
+                    line.price_unit,
+                    line.tax_ids,
+                    fiscal_position=line.move_id.fiscal_position_id,
+                )
                 line._compute_tax_ids()
+                line.price_unit = price_unit
                 line._compute_account_id()
         if lines_without_product:
             res["warning"] = {"title": _("Warning")}

--- a/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
+++ b/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
@@ -4,6 +4,7 @@
 
 import time
 
+from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -16,28 +17,54 @@ class TestProductIdChange(AccountTestInvoicingCommon):
     invoice lines.
     """
 
-    def setUp(self):
-        super().setUp()
-        self.invoice_model = self.env["account.move"]
-        self.fiscal_position_model = self.env["account.fiscal.position"]
-        self.fiscal_position_tax_model = self.env["account.fiscal.position.tax"]
-        self.fiscal_position_account_model = self.env["account.fiscal.position.account"]
-        self.tax_model = self.env["account.tax"]
-        self.account_model = self.env["account.account"]
-        self.pricelist_model = self.env["product.pricelist"]
-        self.res_partner_model = self.env["res.partner"]
-        self.product_tmpl_model = self.env["product.template"]
-        self.product_model = self.env["product.product"]
-        self.invoice_line_model = self.env["account.move.line"]
-        self.account_receivable = self.env["account.account"].search(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.invoice_model = cls.env["account.move"]
+        cls.fiscal_position_model = cls.env["account.fiscal.position"]
+        cls.fiscal_position_tax_model = cls.env["account.fiscal.position.tax"]
+        cls.fiscal_position_account_model = cls.env["account.fiscal.position.account"]
+        cls.tax_model = cls.env["account.tax"]
+        cls.account_model = cls.env["account.account"]
+        cls.pricelist_model = cls.env["product.pricelist"]
+        cls.res_partner_model = cls.env["res.partner"]
+        cls.product_tmpl_model = cls.env["product.template"]
+        cls.product_model = cls.env["product.product"]
+        cls.invoice_line_model = cls.env["account.move.line"]
+        cls.account_receivable = cls.env["account.account"].search(
             [("account_type", "=", "asset_receivable")], limit=1
         )
-        self.account_revenue = self.env["account.account"].search(
+        cls.account_revenue = cls.env["account.account"].search(
             [("account_type", "=", "income")], limit=1
         )
+        cls.partner = cls.res_partner_model.create(dict(name="George"))
+        cls.tax_sale_excl = cls.tax_model.create(
+            {
+                "name": "Sale tax B2B",
+                "type_tax_use": "sale",
+                "amount": "20.00",
+            }
+        )
+        cls.tax_sale_incl = cls.tax_model.create(
+            {
+                "name": "Sale tax B2C",
+                "type_tax_use": "sale",
+                "amount": "20.00",
+                "price_include_override": "tax_included",
+            }
+        )
+        cls.tax_sale_export = cls.tax_model.create(
+            {"name": "Sale tax zero", "type_tax_use": "sale", "amount": "0.00"}
+        )
+        product_tmpl = cls.product_tmpl_model.create(
+            {
+                "name": "Car",
+                "property_account_income_id": cls.account_revenue.id,
+            }
+        )
+        cls.product = product_tmpl.product_variant_id
 
     def test_fiscal_position_id_change(self):
-        partner = self.res_partner_model.create(dict(name="George"))
         account_export_id = self.account_model.sudo().create(
             {
                 "code": "710000AccountInvoiceFiscalPositionUpdate",
@@ -46,37 +73,21 @@ class TestProductIdChange(AccountTestInvoicingCommon):
                 "reconcile": True,
             }
         )
-        tax_sale = self.tax_model.create(
-            {"name": "Sale tax", "type_tax_use": "sale", "amount": "20.00"}
-        )
-
-        tax_export_sale = self.tax_model.create(
-            {"name": "Export tax", "type_tax_use": "sale", "amount": "0.00"}
-        )
-
-        product_tmpl = self.product_tmpl_model.create(
-            {
-                "name": "Car",
-                "list_price": "15000",
-                "taxes_id": [(6, 0, [tax_sale.id])],
-                "property_account_income_id": self.account_revenue.id,
-            }
-        )
-        product = product_tmpl.product_variant_id
-        product.standard_price = 12000
+        self.product.taxes_id = self.tax_sale_excl
+        self.product.lst_price = 12000
         fp = self.fiscal_position_model.create(
             {"name": "fiscal position export", "sequence": 1}
         )
         fp2 = self.fiscal_position_model.create(
             {"name": "fiscal position import", "sequence": 1}
         )
-        partner.write({"property_account_position_id": fp2.id})
+        self.partner.write({"property_account_position_id": fp2.id})
 
         fp_tax_sale = self.fiscal_position_tax_model.create(
             {
                 "position_id": fp.id,
-                "tax_src_id": tax_sale.id,
-                "tax_dest_id": tax_export_sale.id,
+                "tax_src_id": self.tax_sale_excl.id,
+                "tax_dest_id": self.tax_sale_export.id,
             }
         )
 
@@ -90,7 +101,7 @@ class TestProductIdChange(AccountTestInvoicingCommon):
 
         out_invoice = self.invoice_model.create(
             {
-                "partner_id": partner.id,
+                "partner_id": self.partner.id,
                 "ref": "invoice to client",
                 "move_type": "out_invoice",
                 "invoice_date": time.strftime("%Y") + "-04-01",
@@ -100,17 +111,16 @@ class TestProductIdChange(AccountTestInvoicingCommon):
             check_move_validity=False
         ).create(
             {
-                "product_id": product.id,
+                "product_id": self.product.id,
                 "price_unit": 15000,
                 "quantity": 1,
                 "move_id": out_invoice.id,
                 "name": "Car",
-                "account_id": self.account_revenue.id,
             }
         )
         self.assertEqual(
             out_line.tax_ids[0],
-            tax_sale,
+            self.tax_sale_excl,
             "The sale tax off invoice line must be the same of product",
         )
         out_invoice.fiscal_position_id = fp
@@ -134,7 +144,6 @@ class TestProductIdChange(AccountTestInvoicingCommon):
                 "price_unit": 100,
                 "quantity": 1,
                 "move_id": out_invoice.id,
-                "account_id": self.account_revenue.id,
             }
         )
         onchange_result = out_invoice.with_context(
@@ -146,7 +155,7 @@ class TestProductIdChange(AccountTestInvoicingCommon):
         # for all lines without product
         out_invoice_without_prd = self.invoice_model.create(
             {
-                "partner_id": partner.id,
+                "partner_id": self.partner.id,
                 "ref": "invoice to client",
                 "move_type": "out_invoice",
                 "invoice_date": time.strftime("%Y") + "-04-01",
@@ -159,7 +168,6 @@ class TestProductIdChange(AccountTestInvoicingCommon):
                 "price_unit": 100,
                 "quantity": 1,
                 "move_id": out_invoice_without_prd.id,
-                "account_id": self.account_revenue.id,
             }
         )
         onchange_result = out_invoice_without_prd.with_context(
@@ -167,3 +175,143 @@ class TestProductIdChange(AccountTestInvoicingCommon):
         )._onchange_fiscal_position_id_account_invoice_fiscal_position_invoice()
         self.assertTrue(isinstance(onchange_result, dict))
         self.assertEqual(list(onchange_result.keys()), ["warning"])
+
+    def _test_price_conversion(
+        self,
+        original_tax,
+        mapped_tax,
+        product_price,
+        original_subtotal_price,
+        original_total_price,
+        mapped_subtotal_price,
+        mapped_total_price,
+    ):
+        """Test price conversion for a specific tax mapping"""
+        self.product.taxes_id = original_tax
+        self.product.lst_price = product_price
+        fp = self.fiscal_position_model.create(
+            {
+                "name": __name__,
+                "sequence": 99,
+                "tax_ids": [
+                    Command.create(
+                        {
+                            "tax_src_id": original_tax.id,
+                            "tax_dest_id": mapped_tax.id,
+                        }
+                    ),
+                ],
+            }
+        )
+        out_invoice = self.invoice_model.create(
+            {
+                "partner_id": self.partner.id,
+                "ref": "invoice to client",
+                "move_type": "out_invoice",
+                "invoice_date": time.strftime("%Y") + "-04-01",
+                "fiscal_position_id": False,
+            }
+        )
+        # Create a line without fiscal position
+        out_line = self.invoice_line_model.with_context(
+            check_move_validity=False
+        ).create(
+            {
+                "product_id": self.product.id,
+                "quantity": 1,
+                "move_id": out_invoice.id,
+                "name": "Car",
+            }
+        )
+        self.assertEqual(out_line.tax_ids, original_tax)
+        self.assertEqual(out_line.price_subtotal, original_subtotal_price)
+        self.assertEqual(out_line.price_total, original_total_price)
+        out_invoice.fiscal_position_id = fp
+
+        # Create a line with fiscal position (checking Odoo standard behaviour)
+        out_line2 = self.invoice_line_model.with_context(
+            check_move_validity=False
+        ).create(
+            {
+                "product_id": self.product.id,
+                "quantity": 1,
+                "move_id": out_invoice.id,
+                "name": "Car",
+            }
+        )
+        self.assertEqual(out_line2.tax_ids, mapped_tax)
+        self.assertEqual(out_line2.price_subtotal, mapped_subtotal_price)
+        self.assertEqual(out_line2.price_total, mapped_total_price)
+
+        # Check behaviour when applying the change of fiscal position
+        out_invoice.with_context(
+            check_move_validity=False
+        )._onchange_fiscal_position_id_account_invoice_fiscal_position_invoice()
+        self.assertEqual(out_line.tax_ids, mapped_tax)
+        # Result is the same as Odoo standard behaviour
+        self.assertEqual(out_line.price_subtotal, mapped_subtotal_price)
+        self.assertEqual(out_line.price_total, mapped_total_price)
+
+    def test_price_incl_to_zero(self):
+        """Test conversion of price from tax incl to zero (export) tax.
+
+        We don't expect the subtotal price of the line to change.
+        """
+        self._test_price_conversion(
+            self.tax_sale_incl,
+            self.tax_sale_export,
+            product_price=1000,
+            original_subtotal_price=833.33,
+            original_total_price=1000,
+            # Subtotal is not changed, conversion is successful
+            mapped_subtotal_price=833.33,
+            mapped_total_price=833.33,
+        )
+
+    def test_price_incl_to_excl(self):
+        """Test conversion of price from tax incl. to tax excl.
+
+        We don't expect the subtotal price of the line to change.
+        """
+        self._test_price_conversion(
+            self.tax_sale_incl,
+            self.tax_sale_excl,
+            product_price=1000,
+            original_subtotal_price=833.33,
+            original_total_price=1000,
+            # Subtotal is not changed, conversion is successful
+            mapped_subtotal_price=833.33,
+            mapped_total_price=1000,
+        )
+
+    def test_price_zero_to_incl(self):
+        """Test conversion of price from tax zero to tax incl.
+
+        NB. as per Odoo standard behaviour, the subtotal of the price decreases.
+        """
+        self._test_price_conversion(
+            self.tax_sale_export,
+            self.tax_sale_incl,
+            product_price=833.33,
+            original_subtotal_price=833.33,
+            original_total_price=833.33,
+            # Subtotal changes, seems bad
+            mapped_subtotal_price=694.44,
+            mapped_total_price=833.33,
+        )
+
+    def test_price_excl_to_incl(self):
+        """Test conversion of price from tax excl to tax incl.
+
+        NB. as per Odoo standard behaviour, the subtotal of the price decreases.
+        """
+        self._test_price_conversion(
+            self.tax_sale_excl,
+            self.tax_sale_incl,
+            product_price=833.33,
+            original_subtotal_price=833.33,
+            original_total_price=1000,
+            # Subtotal changes, seems bad
+            mapped_subtotal_price=694.44,
+            mapped_total_price=833.33,
+        )


### PR DESCRIPTION
Fixes #1896

This change causes the subtotal amount to remain the same when a fiscal position change triggers a tax update from tax included in price to tax excluded from price.

Tests are added for conversion between tax excluded to tax included as well, but in this case the behaviour is not 'fixed'. The standard behaviour of Odoo in case of tax excl. to tax incl. is to adjust the subtotal amount. The same behaviour is present in the function that this module provides. It might not be what users expect, but it seems that Odoo does not support to preserve the subtotal amount in this case.